### PR TITLE
attributes of Fake objects created by patch_module will not be cleared when Scenario is instantiated, only on Patcher.undo

### DIFF
--- a/test/test_patcher.py
+++ b/test/test_patcher.py
@@ -44,3 +44,8 @@ def test_scenario_should_not_reset_fake_modules():
     patcher.undo()
     assert type(Fake('name').length) is Fake
     assert thing.name is 'original'
+
+
+    Fake('name').length = 222
+    with Scenario() as s:
+        assert type(Fake('name').length) is Fake

--- a/test/test_patcher.py
+++ b/test/test_patcher.py
@@ -42,4 +42,5 @@ def test_scenario_should_not_reset_fake_modules():
     with Scenario() as s:
         assert thing.name.length == 111
     patcher.undo()
+    assert type(Fake('name').length) is Fake
     assert thing.name is 'original'

--- a/test/test_patcher.py
+++ b/test/test_patcher.py
@@ -1,4 +1,5 @@
 from testix import Fake
+from testix import Scenario
 from testix.patch_module import Patcher
 
 class AnObject:
@@ -30,3 +31,15 @@ def test_override_non_existing_attribute():
     assert thing.made_up_attribute is Fake('made_up_attribute')
     patcher.undo()
     assert not hasattr(thing, 'made_up_attribute')
+
+def test_scenario_should_not_reset_fake_modules():
+    patcher = Patcher()
+    thing = AnObject()
+    thing.name = 'original'
+    patcher(thing, 'name')
+    assert thing.name is Fake('name')
+    thing.name.length = 111
+    with Scenario() as s:
+        assert thing.name.length == 111
+    patcher.undo()
+    assert thing.name is 'original'

--- a/testix/fake.py
+++ b/testix/fake.py
@@ -18,6 +18,10 @@ class Fake:
         Fake.__fake_module.add(path_a62df12dd67848be82c505d63b928725)
 
     @staticmethod
+    def unexempt_from_attribute_sweep(path_a62df12dd67848be82c505d63b928725):
+        Fake.__fake_module.remove(path_a62df12dd67848be82c505d63b928725)
+
+    @staticmethod
     def clear_all_attributes():
         for instance in Fake.__registry.values():
             if instance.path_a62df12dd67848be82c505d63b928725 in Fake.__fake_module:

--- a/testix/fake.py
+++ b/testix/fake.py
@@ -4,16 +4,22 @@ from testix import failhooks
 
 class Fake:
     __registry = {}
-    def __new__( cls, path_a62df12dd67848be82c505d63b928725, **attributes ):
+    __dont_clear = set()
+
+    def __new__( cls, path_a62df12dd67848be82c505d63b928725, dont_clear_attributes_a62df12dd67848be82c505d63b928725=False, **attributes ):
         if path_a62df12dd67848be82c505d63b928725 in Fake.__registry:
             return Fake.__registry[path_a62df12dd67848be82c505d63b928725]
         instance = super(Fake, cls).__new__(cls)
         Fake.__registry[path_a62df12dd67848be82c505d63b928725] = instance
+        if dont_clear_attributes_a62df12dd67848be82c505d63b928725:
+            Fake.__dont_clear.add(path_a62df12dd67848be82c505d63b928725)
         return instance
 
     @staticmethod
     def clear_all_attributes():
         for instance in Fake.__registry.values():
+            if instance.path_a62df12dd67848be82c505d63b928725 in Fake.__dont_clear:
+                continue
             Fake.clear_attributes(instance)
 
     @staticmethod

--- a/testix/fake.py
+++ b/testix/fake.py
@@ -4,21 +4,23 @@ from testix import failhooks
 
 class Fake:
     __registry = {}
-    __dont_clear = set()
+    __fake_module = set()
 
-    def __new__( cls, path_a62df12dd67848be82c505d63b928725, dont_clear_attributes_a62df12dd67848be82c505d63b928725=False, **attributes ):
+    def __new__( cls, path_a62df12dd67848be82c505d63b928725, **attributes ):
         if path_a62df12dd67848be82c505d63b928725 in Fake.__registry:
             return Fake.__registry[path_a62df12dd67848be82c505d63b928725]
         instance = super(Fake, cls).__new__(cls)
         Fake.__registry[path_a62df12dd67848be82c505d63b928725] = instance
-        if dont_clear_attributes_a62df12dd67848be82c505d63b928725:
-            Fake.__dont_clear.add(path_a62df12dd67848be82c505d63b928725)
         return instance
+
+    @staticmethod
+    def exempt_from_attribute_sweep(path_a62df12dd67848be82c505d63b928725):
+        Fake.__fake_module.add(path_a62df12dd67848be82c505d63b928725)
 
     @staticmethod
     def clear_all_attributes():
         for instance in Fake.__registry.values():
-            if instance.path_a62df12dd67848be82c505d63b928725 in Fake.__dont_clear:
+            if instance.path_a62df12dd67848be82c505d63b928725 in Fake.__fake_module:
                 continue
             Fake.clear_attributes(instance)
 

--- a/testix/patch_module.py
+++ b/testix/patch_module.py
@@ -13,7 +13,8 @@ class Patcher:
         else:
             original = _SENTINEL
         if mock is None:
-            mock = fake.Fake(attribute, dont_clear_attributes_a62df12dd67848be82c505d63b928725=True)
+            mock = fake.Fake(attribute)
+            fake.Fake.exempt_from_attribute_sweep(mock.path_a62df12dd67848be82c505d63b928725)
         setattr( module, attribute, mock )
         self.__stack.append( ( module, attribute, original, mock ) )
         return mock

--- a/testix/patch_module.py
+++ b/testix/patch_module.py
@@ -13,13 +13,15 @@ class Patcher:
         else:
             original = _SENTINEL
         if mock is None:
-            mock = fake.Fake(attribute)
+            mock = fake.Fake(attribute, dont_clear_attributes_a62df12dd67848be82c505d63b928725=True)
         setattr( module, attribute, mock )
-        self.__stack.append( ( module, attribute, original ) )
+        self.__stack.append( ( module, attribute, original, mock ) )
         return mock
 
     def undo(self):
-        for module, attribute, original in reversed(self.__stack):
+        for module, attribute, original, mock in reversed(self.__stack):
+            if isinstance(mock, fake.Fake):
+                fake.Fake.clear_attributes(mock)
             if original is _SENTINEL:
                 delattr(module, attribute)
             else:

--- a/testix/patch_module.py
+++ b/testix/patch_module.py
@@ -23,6 +23,7 @@ class Patcher:
         for module, attribute, original, mock in reversed(self.__stack):
             if isinstance(mock, fake.Fake):
                 fake.Fake.clear_attributes(mock)
+                fake.Fake.unexempt_from_attribute_sweep(mock.path_a62df12dd67848be82c505d63b928725)
             if original is _SENTINEL:
                 delattr(module, attribute)
             else:


### PR DESCRIPTION
closes #91